### PR TITLE
Remove verbose logging of rpc object.

### DIFF
--- a/lib/rpc/rpcservice.js
+++ b/lib/rpc/rpcservice.js
@@ -13,7 +13,7 @@ var timer = require('./timer');
 // Holds REQ sockets. REP sockets managed by main Communications class
 function RpcService (serviceName, version, meta, logger) {
   EventEmitter.call(this);
-  
+
   if (!serviceName) {
     throw new Error('Cannot create service, no serviceName');
   }
@@ -73,9 +73,9 @@ RpcService.prototype._logRpc = function(rpc) {
   var log = formatLogMsg(rpc);
 
   if (rpc.response.error) {
-    this._logger.warn(log, rpc);
+    this._logger.warn(log);
   } else {
-    this._logger.debug(log, rpc);
+    this._logger.debug(log);
   }
 };
 
@@ -212,7 +212,7 @@ RpcService.prototype._handleResponse = function (msg, response) {
   var replyTo = msg.properties.replyTo;
   var options = {
     deliveryMode: true,
-    correlationId: process.domain && process.domain.cid || guid()
+    correlationId: process.domain && process.domain.cid || msg.properties.correlationId
   };
 
   var chunk = new Buffer(JSON.stringify(response));


### PR DESCRIPTION
Removes logging of rpc object, also uses request's uuid for correlation id if domain cid is absent.
